### PR TITLE
:bug: search change時のバグを修正

### DIFF
--- a/src/pages/tags/tags.ts
+++ b/src/pages/tags/tags.ts
@@ -120,7 +120,7 @@ function tags(searchKeyword: string, pathdata: PageChangeEvent) {
         const searchChangeListener = ({
             detail,
         }: CustomEvent<SearchChangeEvent>) => {
-            if (detail.before.path.split("/")[1] === "tags") {
+            if (detail.before.path.split("/")[1] !== "artworks") {
                 console.log("search change");
                 renderingWithSearchData(searchKeyword);
             }


### PR DESCRIPTION
pixiv-tag-filter-searchChange時、前ページが/tags以外だとソートが動作しなかったため、/artworksでない場合に条件を変更